### PR TITLE
fix(resolve): keep no specifiers imports for styles

### DIFF
--- a/packages/vue-note/src/compilor/resolve.ts
+++ b/packages/vue-note/src/compilor/resolve.ts
@@ -92,7 +92,7 @@ function dedupeImports(rawImports: ImportDeclaration[], ctx: Rollup.TransformPlu
     })
   })
 
-  return imports.filter(decl => decl.specifiers && decl.specifiers.length > 0)
+  return imports
 }
 
 function getImportedUniqueID(node: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier, parent: ImportDeclaration): string {

--- a/playground/src/app.ts
+++ b/playground/src/app.ts
@@ -2,6 +2,7 @@
 /* eslint-disable unused-imports/no-unused-vars */
 import { ref } from 'vue'
 import { defineCommentComponent, defineTemplate } from 'vue-note'
+import './style.css'
 
 const AppHome = defineCommentComponent(() => {
   const props = defineProps<{

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1,0 +1,3 @@
+body{
+  background: red;
+}

--- a/playground/vite-env.d.ts
+++ b/playground/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const css: { [key: string]: string }
+  export default css
+}


### PR DESCRIPTION
The style imports are removed while resolving

<img width="732" height="157" alt="current" src="https://github.com/user-attachments/assets/3dfbe25e-eb20-49a1-8962-50902af69289" />

remove filter to fix it